### PR TITLE
Upgrade of `oauth4webapi ` to version 3.x

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -76,7 +76,6 @@
         "pcss",
         "postcss"
     ],
-
     // Enable SonarLint
     "sonarlint.connectedMode.project": {
         "connectionId": "volverjs",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.0] - 2024-10-02
+
+### Fixed
+- Upgrade of `oauth4webapi` to version 3.x, which includes breaking changes.
+
+### Changed
+- Removed `tokenEndpointAuthMethod` option from `OAuthClient` constructor, use `clientAuthentication` instead.
+
 ## [0.0.3] - 2024-10-02
 
 ### Added 

--- a/README.md
+++ b/README.md
@@ -68,16 +68,16 @@ The `OAuthClient` class is a wrapper of [oauth4webapi](https://github.com/panva/
 By default it uses `LocalStorage` to store the refresh token and the code verifier.
 
 ```typescript
-import { OAuthClient, SessionStorage } from '@volverjs/auth-vue'
+import { ClientSecretBasic, OAuthClient, SessionStorage } from '@volverjs/auth-vue'
 
 const authClient = new OAuthClient({
     // The URL of the OAuth issuer
     url: 'https://my-oauth-server.com',
     // The client id of the application
     clientId: 'my-client-id',
-    // The client authentication method, default: 'none'
-    // Are also supported: 'client_secret_basic', 'client_secret_post' and 'private_key_jwt'
-    tokenEndpointAuthMethod: 'none',
+    // The client authentication method, default: None()
+    // Are also supported: ClientSecretPost, ClientSecretBasic, PrivateKeyJwt, None, TlsClientAuth
+    clientAuthentication: ClientSecretBasic('my-client-secret'),
     // The scopes requested to the OAuth server
     scopes: 'openid profile email',
     // The storage to use for persisting the refresh token, default: new LocalStorage('oauth')

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         "vue": "^3.5.x"
     },
     "dependencies": {
-        "oauth4webapi": "^2.17.0"
+        "oauth4webapi": "^3.8.2"
     },
     "devDependencies": {
         "@antfu/eslint-config": "^5.4.1",
@@ -104,7 +104,6 @@
         "vite-plugin-dts": "^4.5.4",
         "vitest": "^3.2.4",
         "vitest-fetch-mock": "^0.4.5",
-        "vue": "^3.5.22",
         "vue-tsc": "^3.1.0"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,11 @@ importers:
   .:
     dependencies:
       oauth4webapi:
-        specifier: ^2.17.0
-        version: 2.17.0
+        specifier: ^3.8.2
+        version: 3.8.2
+      vue:
+        specifier: ^3.5.x
+        version: 3.5.22(typescript@5.9.3)
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^5.4.1
@@ -45,9 +48,6 @@ importers:
       vitest-fetch-mock:
         specifier: ^0.4.5
         version: 0.4.5(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.19)(happy-dom@19.0.2)(yaml@2.8.1))
-      vue:
-        specifier: ^3.5.22
-        version: 3.5.22(typescript@5.9.3)
       vue-tsc:
         specifier: ^3.1.0
         version: 3.1.0(typescript@5.9.3)
@@ -691,8 +691,8 @@ packages:
     resolution: {integrity: sha512-qsaFBA3e09MIDAGFUrTk+dzqtfv1XPVz8t8d1f0ybTzrCY7BKiMC5cjrl1O/P7UmHsNyW90EYSkU/ZWpmXelag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vitest/eslint-plugin@1.3.14':
-    resolution: {integrity: sha512-CaS/6uwVT/F80CXop7CP6V+emsvNHyVzl79Y4CCRB4U3vjChUPrI/ezThN+sWG+3YO238gAOMg6rK8gcLdAImw==}
+  '@vitest/eslint-plugin@1.3.13':
+    resolution: {integrity: sha512-QfzXd1+lCY3dIqPHOZlagA2bJYoWC5yAU3adv8Gks0rHAL6FpyXKYBiyMCuU6mRrbKUMphGqwDQobinOvYgJig==}
     peerDependencies:
       eslint: '>= 8.57.0'
       typescript: '>= 5.0.0'
@@ -1900,8 +1900,8 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
-  oauth4webapi@2.17.0:
-    resolution: {integrity: sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ==}
+  oauth4webapi@3.8.2:
+    resolution: {integrity: sha512-FzZZ+bht5X0FKe7Mwz3DAVAmlH1BV5blSak/lHMBKz0/EBMhX6B10GlQYI51+oRp8ObJaX0g6pXrAxZh5s8rjw==}
 
   object-deep-merge@1.0.5:
     resolution: {integrity: sha512-3DioFgOzetbxbeUq8pB2NunXo8V0n4EvqsWM/cJoI6IA9zghd7cl/2pBOuWRf4dlvA+fcg5ugFMZaN2/RuoaGg==}
@@ -2496,7 +2496,7 @@ snapshots:
       '@stylistic/eslint-plugin': 5.4.0(eslint@9.36.0)
       '@typescript-eslint/eslint-plugin': 8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0)(typescript@5.9.3))(eslint@9.36.0)(typescript@5.9.3)
       '@typescript-eslint/parser': 8.45.0(eslint@9.36.0)(typescript@5.9.3)
-      '@vitest/eslint-plugin': 1.3.14(eslint@9.36.0)(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.19)(happy-dom@19.0.2)(yaml@2.8.1))
+      '@vitest/eslint-plugin': 1.3.13(eslint@9.36.0)(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.19)(happy-dom@19.0.2)(yaml@2.8.1))
       ansis: 4.2.0
       cac: 6.7.14
       eslint: 9.36.0
@@ -3070,7 +3070,7 @@ snapshots:
       '@typescript-eslint/types': 8.45.0
       eslint-visitor-keys: 4.2.1
 
-  '@vitest/eslint-plugin@1.3.14(eslint@9.36.0)(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.19)(happy-dom@19.0.2)(yaml@2.8.1))':
+  '@vitest/eslint-plugin@1.3.13(eslint@9.36.0)(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.19)(happy-dom@19.0.2)(yaml@2.8.1))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.45.0
       '@typescript-eslint/utils': 8.45.0(eslint@9.36.0)(typescript@5.9.3)
@@ -4547,7 +4547,7 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  oauth4webapi@2.17.0: {}
+  oauth4webapi@3.8.2: {}
 
   object-deep-merge@1.0.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - esbuild

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,11 @@
 import type { App, InjectionKey } from 'vue'
 import type { OAuthClientOptions } from './OAuthClient'
+import {
+    ClientSecretBasic,
+    ClientSecretPost,
+    PrivateKeyJwt,
+    TlsClientAuth,
+} from 'oauth4webapi'
 import { getCurrentInstance, inject } from 'vue'
 import { OAuthClient } from './OAuthClient'
 
@@ -7,6 +13,12 @@ export { OAuthClient }
 export { LocalStorage } from './LocalStorage'
 export { SessionStorage } from './SessionStorage'
 export { Storage } from './Storage'
+export {
+    ClientSecretBasic,
+    ClientSecretPost,
+    PrivateKeyJwt,
+    TlsClientAuth,
+}
 
 export const authClientInjectionKey = Symbol('') as InjectionKey<OAuthClient>
 
@@ -77,3 +89,5 @@ export function useOAuthClient(options?: OAuthClientOptions) {
     }
     return client
 }
+
+export {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,5 @@
 import type { App, InjectionKey } from 'vue'
 import type { OAuthClientOptions } from './OAuthClient'
-import {
-    ClientSecretBasic,
-    ClientSecretPost,
-    PrivateKeyJwt,
-    TlsClientAuth,
-} from 'oauth4webapi'
 import { getCurrentInstance, inject } from 'vue'
 import { OAuthClient } from './OAuthClient'
 
@@ -18,7 +12,7 @@ export {
     ClientSecretPost,
     PrivateKeyJwt,
     TlsClientAuth,
-}
+} from 'oauth4webapi'
 
 export const authClientInjectionKey = Symbol('') as InjectionKey<OAuthClient>
 
@@ -89,5 +83,3 @@ export function useOAuthClient(options?: OAuthClientOptions) {
     }
     return client
 }
-
-export {}

--- a/test/oAuthClient.test.ts
+++ b/test/oAuthClient.test.ts
@@ -5,13 +5,13 @@ import { OAuthClient } from '../src/OAuthClient'
 const fetchMock = createFetchMock(vi)
 
 const response = JSON.stringify({
-    token_endpoint: 'http://dummy.com/oauth2/v2.0/token',
+    token_endpoint: 'https://dummy.com/oauth2/v2.0/token',
     token_endpoint_auth_methods_supported: [
         'client_secret_post',
         'private_key_jwt',
         'client_secret_basic',
     ],
-    jwks_uri: 'http://dummy.com/discovery/v2.0/keys',
+    jwks_uri: 'https://dummy.com/discovery/v2.0/keys',
     response_modes_supported: ['query', 'fragment', 'form_post'],
     subject_types_supported: ['pairwise'],
     id_token_signing_alg_values_supported: ['RS256'],
@@ -22,14 +22,14 @@ const response = JSON.stringify({
         'id_token token',
     ],
     scopes_supported: ['openid', 'profile', 'email', 'offline_access'],
-    issuer: 'http://dummy.com',
+    issuer: 'https://dummy.com',
     request_uri_parameter_supported: false,
     userinfo_endpoint: 'https://graph.microsoft.com/oidc/userinfo',
-    authorization_endpoint: 'http://dummy.com/oauth2/v2.0/authorize',
-    device_authorization_endpoint: 'http://dummy.com/oauth2/v2.0/devicecode',
+    authorization_endpoint: 'https://dummy.com/oauth2/v2.0/authorize',
+    device_authorization_endpoint: 'https://dummy.com/oauth2/v2.0/devicecode',
     http_logout_supported: true,
     frontchannel_logout_supported: true,
-    end_session_endpoint: 'http://dummy.com/oauth2/v2.0/logout',
+    end_session_endpoint: 'https://dummy.com/oauth2/v2.0/logout',
     claims_supported: [
         'sub',
         'iss',
@@ -51,7 +51,7 @@ const response = JSON.stringify({
         'c_hash',
         'email',
     ],
-    kerberos_endpoint: 'http://dummy.com/kerberos',
+    kerberos_endpoint: 'https://dummy.com/kerberos',
     tenant_region_scope: 'EU',
     cloud_instance_name: 'microsoftonline.com',
     cloud_graph_host_name: 'graph.windows.net',
@@ -67,7 +67,7 @@ describe('oAuthClient', () => {
     it('should create a new OAuthClient instance', () => {
         const client = new OAuthClient({
             clientId: '864b865f-3025-4c48-b4ed-c16676a5b676',
-            url: 'http://dummy.com',
+            url: 'https://dummy.com',
         })
         expect(client).toBeInstanceOf(OAuthClient)
     })
@@ -76,12 +76,12 @@ describe('oAuthClient', () => {
         fetchMock.mockResponse(response, {
             status: 200,
             statusText: 'ok',
-            url: 'http://dummy.com/.well-known/openid-configuration',
+            url: 'https://dummy.com/.well-known/openid-configuration',
         })
         const client = new OAuthClient({
             clientId: 'test',
             scopes: ['test'],
-            url: 'http://dummy.com',
+            url: 'https://dummy.com',
         })
         expect(client).toBeInstanceOf(OAuthClient)
         await client.initialize()
@@ -99,19 +99,19 @@ describe('oAuthClient', () => {
         fetchMock.mockResponse(response, {
             status: 200,
             statusText: 'ok',
-            url: 'http://dummy.com/.well-known/openid-configuration',
+            url: 'https://dummy.com/.well-known/openid-configuration',
         })
         const client = new OAuthClient({
             clientId: 'test',
             scopes: ['test'],
-            url: 'http://dummy.com',
+            url: 'https://dummy.com',
         })
         expect(client).toBeInstanceOf(OAuthClient)
         await client.initialize()
         expect(client.initialized).toBe(true)
         await client.authorize()
         const urlToTest = mockResponse.mock.calls[0][0]
-        expect(urlToTest).toContain('http://dummy.com/oauth2/v2.0/authorize')
+        expect(urlToTest).toContain('https://dummy.com/oauth2/v2.0/authorize')
         expect(urlToTest).toContain('scope=test')
         expect(urlToTest).toContain('client_id=test')
     })


### PR DESCRIPTION
fixed: upgrade of `oauth4webapi` to version 3.x, which includes breaking changes.
BREAKING CHANGE: Removed `tokenEndpointAuthMethod` option from `OAuthClient` constructor, use `clientAuthentication` instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced clientAuthentication option for OAuthClient with support for ClientSecretBasic, ClientSecretPost, PrivateKeyJwt, and TlsClientAuth.
  - Exposed authentication helpers for easier configuration.

- Refactor
  - Replaced tokenEndpointAuthMethod with clientAuthentication across the OAuth flow (breaking change).

- Documentation
  - Updated README and CHANGELOG with new authentication usage and 1.0.0 notes.

- Chores
  - Upgraded oauth4webapi to v3.x.
  - Adjusted workspace/build settings and dependencies.

- Tests
  - Updated tests to use HTTPS endpoints and reflect new authentication configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->